### PR TITLE
fix: Replace link to webxr page with the one in book

### DIFF
--- a/src/architecture/concurrency-and-parallelism.md
+++ b/src/architecture/concurrency-and-parallelism.md
@@ -37,7 +37,7 @@ Here are some ways that we take advantage of both:
 * _GC JS concurrent with layout_ - Under most any design with concurrent JS and layout, JS is going to be waiting to query layout sometimes, perhaps often.
   This will be the most opportune time to run the GC.
 
-For information on the design of WebXR see the [in-tree documentation](https://github.com/servo/servo/blob/main/docs/components/webxr.md).
+For information on the design of WebXR see the [in-tree documentation](./webxr.md).
 
 ## Challenges
 


### PR DESCRIPTION
The page regarding WebXR has been migrated from servo repot to this book. This PR is to replace the link.