### PR TITLE
android: Update required NDK version

### DIFF
--- a/src/hacking/building-for-android.md
+++ b/src/hacking/building-for-android.md
@@ -10,12 +10,12 @@ After cloning the repository and [installing dependencies common to all targets]
 
 To install the NDK and SDK using Android Studio, refer to the guidelines on the website.
 For the SDK, install the Android 33 platform.
-The NDK must be version r25c.
+The NDK must be version r26c.
 Versions before and after change the layout of the NDK and add or remove files.
 
 If you are using the `sdkmanager` tool, you can do:
 ```sh
-tools/bin/sdkmanager platform-tools "platforms;android-33" "build-tools;33.0.2" "ndk;25.2.9519653"
+tools/bin/sdkmanager platform-tools "platforms;android-33" "build-tools;33.0.2" "ndk;26.2.11394342"
 ```
 
 Set the following environment variables while building.


### PR DESCRIPTION
Servo (and mozjs) currently [require r26c](https://github.com/servo/servo/blob/9fdaf9bf0c6958356b8e3b4f5d03f838c13c6307/python/servo/platform/build_target.py#L139). 
The version number was taken from the android ndk
github releases: https://github.com/android/ndk/releases/tag/r26c