### PR TITLE
android: update the default architecture

### DIFF
--- a/src/hacking/building-for-android.md
+++ b/src/hacking/building-for-android.md
@@ -35,17 +35,17 @@ in the shell session before invoking ./mach commands
 
 ## Build Servo
 
-In the following sub-commands the `--android` flag is short for `--target armv7-linux-androideabi`
+In the following sub-commands the `--android` flag is short for `--target aarch64-linux-android`
 
 ```sh
 # Replace "--release" with "--dev" to create an unoptimized debug build.
 ./mach build --release --android
 ```
 
-For running in an emulator however, you’ll likely want to build for Android x86 instead:
+For running in an emulator however, you’ll likely want to build for Android x86-64 instead:
 
 ```sh
-./mach build --release --target i686-linux-android
+./mach build --release --target x86_64-linux-android
 ```
 
 ## Installing and running on-device


### PR DESCRIPTION
The default architecture specified by `--android` was changed in servo/servo#33379, so this PR updates the documentation to reflect that. In addition this updates the build command for targeting emulators to use the 64-bit version as well.