### PR TITLE
Add note for Windows users in editor-support.md

### DIFF
--- a/src/hacking/editor-support.md
+++ b/src/hacking/editor-support.md
@@ -53,6 +53,10 @@ To enable [optional build settings](building-servo.md#optional-build-settings), 
 }
 ```
 
+### Windows Users
+
+If you are on Windows, you will need to use `./mach.bat` instead of just `./mach`. Not doing so will cause rust-analyzer to throw an error when running any of these commands.
+
 ### NixOS users
 
 If you are on NixOS and using `--use-crown`, you should also set CARGO_BUILD_RUSTC in `.vscode/settings.json` as follows, where `/nix/store/.../crown` is the output of `nix-shell --run 'command -v crown'`.


### PR DESCRIPTION
We worked out on Zulip that the reason the rust-analyzer commands weren't working on Windows was because we were using the `mach` shell script instead of the `mach.bat` file. This adds a note so that hopefully no one else runs into it when setting things up.