### PR TITLE
update instruction for devenv setup to include `uv`

### DIFF
--- a/src/hacking/setting-up-your-environment.md
+++ b/src/hacking/setting-up-your-environment.md
@@ -25,7 +25,11 @@ If you have problems setting up your environment that you can’t solve, you can
 
 - `curl --version` should print a version like 7.83.1 or 8.4.0
   - On Windows, type `curl.exe --version` instead, to avoid getting the PowerShell alias for `Invoke-WebRequest`
-- `python --version` should print **3.11.0 or newer** (3.11.1, 3.12.0, …)
+- `uv --version` should print **0.4.30 or newer**
+  - Servo's `mach` build tool depends on `uv` to provision a pinned version of Python (set by the `.python-version` file in the repo) and create a local virtual environment (`.venv` directory) into which the python dependency modules are installed.
+  - If the system already has an installation of the required Python version, then `uv` will just symlink to that installation to save disk space.
+  - If the versions do not match or no Python installation is present on the host, then `uv` will download the required binaries.
+  - Using an externally managed Python installation for executing `mach` as a Python script is currently not supported.
 - `rustup --version` should print a version like 1.26.0
 - (Windows only) `choco --version` should print a version like 2.2.2
 - (macOS only) `brew --version` should print a version like 4.2.17
@@ -34,7 +38,7 @@ If you have problems setting up your environment that you can’t solve, you can
 
 Note that `curl` will already be installed on Windows 1804 or newer.
 
-- Download and install `python` [from the Python website](https://www.python.org/downloads/windows/)
+- Download and install `uv` [from the uv website](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)
 - Download and install `choco` [from the Chocolatey website](https://chocolatey.org/install#individual)
 - **If you already have `rustup`,** download the [Community edition of Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)
 - **If you don’t have `rustup`,** download and run the `rustup` installer: [`rustup-init.exe`](https://win.rustup.rs/)
@@ -59,29 +63,26 @@ Servo will try to search for the appropriate version of Visual Studio, but havin
 
 Note that `curl` will already be installed on macOS.
 
-- Download and install `python` [from the Python website](https://www.python.org/downloads/macos/)
+- Download and install `uv` [from the uv website](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)
 - Download and install [Xcode](https://developer.apple.com/xcode/)
 - Download and install `brew` [from the Homebrew website](https://brew.sh/)
 - Download and install `rustup` [from the rustup website](https://rustup.rs/)
 
 ## Tools for Linux
 
-- Install `curl` and `python`:
-  - Arch: `sudo pacman -S --needed curl python python-pip`
-  - Debian, Ubuntu: `sudo apt install curl python3-pip python3-venv`
-  - Fedora: `sudo dnf install curl python3 python3-pip python3-devel`
-  - Gentoo: `sudo emerge net-misc/curl dev-python/pip`
+- Install `curl`:
+  - Arch: `sudo pacman -S --needed curl`
+  - Debian, Ubuntu: `sudo apt install curl`
+  - Fedora: `sudo dnf install curl`
+  - Gentoo: `sudo emerge net-misc/curl`
+- Download and install `uv` [from the uv website](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)
 - Download and install `rustup` [from the rustup website](https://rustup.rs/)
 
 On **NixOS**, type `nix-shell` to enter a shell with all of the necessary tools and dependencies.
-You can install `python3` to allow [mach](mach.md) to run `nix-shell` automatically:
-
-- `environment.systemPackages = [ pkgs.python3 ];` (install globally)
-- `home.packages = [ pkgs.python3 ];` (install with [Home Manager](https://nix-community.github.io/home-manager/))
 
 ## Dependencies for any Linux distro, using Nix { #nix-method }
 
-- Make sure you have `curl` and `python` installed (see [*Tools for Linux*](#tools-for-linux))
+- Make sure you have `curl` installed (see [*Tools for Linux*](#tools-for-linux))
 - Make sure you have the [runtime dependencies](../running-servoshell.md#runtime-dependencies) installed as well
 - [Install Nix](https://nixos.org/download), the package manager — the easiest way is to use the installer, with either the multi-user or single-user installation (your choice)
 - Tell [mach](mach.md) to use Nix: `export MACH_USE_NIX=`
@@ -90,7 +91,7 @@ You can install `python3` to allow [mach](mach.md) to run `nix-shell` automatica
 **(including Manjaro)**
 
 <!-- https://archlinux.org/packages/ -->
-- `sudo pacman -S --needed curl python python-pip`
+- `sudo pacman -S --needed curl`
 
 - `sudo pacman -S --needed base-devel git mesa cmake libxmu pkg-config ttf-fira-sans harfbuzz ccache llvm clang autoconf2.13 gstreamer gstreamer-vaapi gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly vulkan-icd-loader`
 
@@ -99,7 +100,7 @@ You can install `python3` to allow [mach](mach.md) to run `nix-shell` automatica
 
 <!-- https://packages.debian.org -->
 <!-- https://packages.ubuntu.com -->
-- `sudo apt install curl python3-pip python3-venv`
+- `sudo apt install curl`
 
 <!-- see python/servo/platform/linux.py for how to update this -->
 - `sudo apt install build-essential ccache clang cmake curl g++ git gperf libdbus-1-dev libfreetype6-dev libgl1-mesa-dri libgles2-mesa-dev libglib2.0-dev gstreamer1.0-plugins-good l gstreamer1.0-plugins-bad libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-ugly gstreamer1.0-plugins-base libgstreamer-plugins-base1.0-dev gstreamer1.0-libav libgstrtspserver-1.0-dev gstreamer1.0-tools libges-1.0-dev libharfbuzz-dev liblzma-dev libudev-dev libunwind-dev libvulkan1 libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev`
@@ -108,21 +109,18 @@ You can install `python3` to allow [mach](mach.md) to run `nix-shell` automatica
 
 ## Dependencies for Fedora { #dependencies-for-fedora }
 
-<!-- https://packages.fedoraproject.org -->
-* `sudo dnf install python3 python3-pip python3-devel`
-
 <!-- see python/servo/platform/linux.py for how to update this -->
 * `sudo dnf install libtool gcc-c++ libXi-devel freetype-devel libunwind-devel mesa-libGL-devel mesa-libEGL-devel glib2-devel libX11-devel libXrandr-devel gperf fontconfig-devel cabextract ttmkfdir expat-devel rpm-build cmake libXcursor-devel libXmu-devel dbus-devel ncurses-devel harfbuzz-devel ccache clang clang-libs llvm python3-devel gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good gstreamer1-plugins-bad-free-devel gstreamer1-plugins-ugly-free libjpeg-turbo-devel zlib libjpeg vulkan-loader`
 
 ## Dependencies for Gentoo { #dependencies-for-gentoo }
 
 <!-- https://packages.gentoo.org -->
-- `sudo emerge net-misc/curl media-libs/freetype media-libs/mesa dev-util/gperf dev-python/pip dev-libs/openssl media-libs/harfbuzz dev-util/ccache sys-libs/libunwind x11-libs/libXmu x11-base/xorg-server sys-devel/clang media-libs/gstreamer media-libs/gst-plugins-base media-libs/gst-plugins-good media-libs/gst-plugins-bad media-libs/gst-plugins-ugly media-libs/vulkan-loader`
+- `sudo emerge net-misc/curl media-libs/freetype media-libs/mesa dev-util/gperf dev-libs/openssl media-libs/harfbuzz dev-util/ccache sys-libs/libunwind x11-libs/libXmu x11-base/xorg-server sys-devel/clang media-libs/gstreamer media-libs/gst-plugins-base media-libs/gst-plugins-good media-libs/gst-plugins-bad media-libs/gst-plugins-ugly media-libs/vulkan-loader`
 
 ## Dependencies for openSUSE { #dependencies-for-opensuse }
 
 <!-- https://search.opensuse.org/packages/ -->
-- `sudo zypper install libX11-devel libexpat-devel Mesa-libEGL-devel Mesa-libGL-devel cabextract cmake dbus-1-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel gperf harfbuzz-devel libXcursor-devel libXi-devel libXmu-devel libXrandr-devel libopenssl-devel python3-pip rpm-build ccache llvm-clang libclang autoconf213 gstreamer-devel gstreamer-plugins-base-devel gstreamer-plugins-good gstreamer-plugins-bad-devel gstreamer-plugins-ugly vulkan-loader libvulkan1`
+- `sudo zypper install libX11-devel libexpat-devel Mesa-libEGL-devel Mesa-libGL-devel cabextract cmake dbus-1-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel gperf harfbuzz-devel libXcursor-devel libXi-devel libXmu-devel libXrandr-devel libopenssl-devel rpm-build ccache llvm-clang libclang autoconf213 gstreamer-devel gstreamer-plugins-base-devel gstreamer-plugins-good gstreamer-plugins-bad-devel gstreamer-plugins-ugly vulkan-loader libvulkan1`
 
 ## Dependencies for Void Linux { #dependencies-for-void-linux }
 


### PR DESCRIPTION
`mach` now [depends on `uv`][1] being already installed on the host to bootstrap the Python environment. This change updates the `Setting up your environment` to include the steps for installing `uv` on the host system.

[1]: https://github.com/servo/servo/pull/34632