### PR TITLE
Add Clang tools to Tools for Windows

### DIFF
--- a/src/hacking/setting-up-your-environment.md
+++ b/src/hacking/setting-up-your-environment.md
@@ -52,6 +52,8 @@ Note that `curl` will already be installed on Windows 1804 or newer.
     (`Microsoft.VisualStudio.Component.VC.ATL`)
   - **C++ MFC for latest v143 build tools (x86 & x64)**<br>
     (`Microsoft.VisualStudio.Component.VC.ATLMFC`)
+  - **C++ Clang tools for Windows (19.1.1 - x64/x86)<br>
+    (`Microsoft.VisualStudio.VC.Llvm.Clang`)
 
 <div class="warning _note">
 


### PR DESCRIPTION
I was unable to build `crown` as part of the environment perp step `./mach bootstrap --skip-platform` on Visual Studio 2022 on Windows. The issue was that ldd-link.exe was not found. Researching that problem, I found that it is resolved by installing the C++ Clang Tools for Windows. I believe that this VS2022 package needs to be added in the prerequisite steps for building on Windows, and have done so with this PR.