### PR TITLE
update try labels and `mach try` syntax

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -49,8 +49,7 @@ If you do not have permission to add labels to your pull request, add a comment 
 | Label              | Runs unit tests on | Runs web tests on          |
 |--------------------|--------------------|----------------------------|
 | `T-full`           | All platforms      | Linux                      |
-| `T-linux-wpt-2013` | Linux              | Linux (only legacy layout) |
-| `T-linux-wpt-2020` | Linux              | Linux (skip legacy layout) |
+| `T-linux-wpt`      | Linux              | Linux                      |
 | `T-macos`          | macOS              | (none)                     |
 | `T-windows`        | Windows            | (none)                     |
 

--- a/src/hacking/testing.md
+++ b/src/hacking/testing.md
@@ -91,7 +91,7 @@ Instead, consider building with `mach build -r` and testing with `mach test-wpt 
 ### Running Web Platform Tests on your GitHub fork
 
 Alternatively, you can execute the tests on GitHub-hosted runners using `mach try`.
-Usually, `mach try linux-wpt-2020` (all tests, linux, `layout-2020`) will be enough.
+Usually, `mach try linux-wpt` (all tests, linux) will be enough.
 
 You can view the run results in your fork under the "Actions" tab.
 Any failed tasks will include a list of stable unexpected results at the bottom of the log.


### PR DESCRIPTION
Legacy layout has been removed, so we can simplify the documentation.