### PR TITLE
Improve documentation for Zed editor

### DIFF
--- a/src/hacking/editor-support.md
+++ b/src/hacking/editor-support.md
@@ -51,9 +51,10 @@ In your `./zed/settings.json` file you need something like this:
         "check": {
           "overrideCommand": [
             "./mach",
-            "cargo-clippy",
+            "clippy",
             "--message-format=json",
             "--target-dir",
+            "target/lsp",
             "--feature",
             "tracing,tracing-perfetto"
           ]
@@ -63,7 +64,7 @@ In your `./zed/settings.json` file you need something like this:
           "buildScripts": {
             "overrideCommand": [
               "./mach",
-              "cargo-clippy",
+              "clippy",
               "--message-format=json",
               "--target-dir",
               "target/lsp",
@@ -71,6 +72,18 @@ In your `./zed/settings.json` file you need something like this:
               "tracing,tracing-perfetto"
             ]
           }
+        },
+        "rustfmt": {
+          "extraArgs": [
+            "--config",
+            "unstable_features=true",
+            "--config",
+            "binop_separator=Back",
+            "--config",
+            "imports_granularity=Module",
+            "--config",
+            "group_imports=StdExternalCrate"
+          ]
         }
       }
     }


### PR DESCRIPTION
Fix some issues with the previous build part of the Zed editor setup and
add support for using `rustfmt` for format on save.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
