### PR TITLE
Add instructions for capturing devtools protocol logs.

### DIFF
--- a/src/hacking/using-devtools.md
+++ b/src/hacking/using-devtools.md
@@ -58,3 +58,21 @@ location.reload()
 
 **Note:** support for DevTools features is still a work in progress, and it can break in future versions of Firefox if there are changes to the messaging protocol.
 </div>
+
+## Capturing protocol traffic from Firefox
+
+A lot of work to improve developer tool support in Servo requires reverse-engineering the working implementation in Firefox.
+One of the most efficient ways to do this is to observe a successful session in Firefox and record the bidirectional protocol traffic between the server and the client.
+To capture a log of the trafic in a Firefox devtools session that does not involve Servo, follow these steps:
+
+1. Open a terminal window. This window will eventually contain the protocol logs.
+1. Launch Firefox from the terminal: `firefox --new-instance --profile devtools-testing` (on macOS you may need `/Applications/Firefox.app/Contents/MacOS/firefox`)
+1. Open about:config
+1. Set `browser.dom.window.dump.enabled` to true
+1. Set `devtools.debugger.log` to true
+1. Set `devtools.debugger.log.verbose` to true
+1. Load a page that is relevant to your developer tools feature
+1. Interact with the developer tools feature
+1. Close Firefox
+
+The terminal window now contains full debug server logs; copy them to somewhere for further analysis.


### PR DESCRIPTION
The instructions in https://github.com/servo/servo/blob/main/etc/devtools_parser.py work inconsistently and are missing required preferences. These steps require no other tools and work consistently for me.