### PR TITLE
Add section on how to enable LSP features in cross-compiling case

### DIFF
--- a/src/hacking/editor-support.md
+++ b/src/hacking/editor-support.md
@@ -37,6 +37,16 @@ Notes:
 - **Windows*: If you are on Windows, you will need to use `./mach.bat` instead of just `./mach`.
   If you do not, you may receive an error saying that the command executed is not a valid Win32 application.
 
+### Autocompletions for platform-specific code
+
+If you're cross-compiling, autocompletions and other LSP features might not work. This is because rust-analyzer is targeting the host platform by default.  
+
+To enable LSP features for Android-specific code, add the following bit to your `.vscode/settings.json`:
+
+```json
+  "rust-analyzer.cargo.target": "aarch64-linux-android"
+```
+
 ## Zed
 
 If you are using Zed, you must do something very similar to what is described for Visual Studio Code, but the Zed configuration file expects a slightly different syntax.


### PR DESCRIPTION
As mentioned on Zulip: [#general > VSCode/rust-analyzer for Android-specific code](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/VSCode.2Frust-analyzer.20for.20Android-specific.20code/with/523908110)

I wrote a few words about how to get LSP stuff to work when doing Android dev, which tripped me up yesterday.
Suggestions on how to word things better are welcome.