### PR TITLE
Remove info on Layout 2013 from layout.md

### DIFF
--- a/src/architecture/layout.md
+++ b/src/architecture/layout.md
@@ -2,14 +2,7 @@
 
 # Layout
 
-Servo has two layout systems:
-
- - Layout (Layout 2020): This is a new layout system for Servo which doesn't yet have all the features of the legacy layout, but will have support for proper fragmentation.
-For more on the benefits of the new layout system, see [Layout 2020](https://github.com/servo/servo/wiki/Layout-2020).
-The architecture described below refers to the new layout system.
-For more information about why we wrote a new layout engine see the [Servo Layout Engines Report](https://github.com/servo/servo/wiki/Servo-Layout-Engines-Report).
- - Legacy layout (Layout 2013): This is the original layout engine written for Servo.
-This layout engine is currently in maintenance mode.
+Servo's current layout system is known as Layout 2020. It [supersedes](https://github.com/servo/servo/wiki/Servo-Layout-Engines-Report) the now-removed original layout system.
 
 Layout happens in three phases: box tree construction, fragment tree construction, and display list construction.
 Once a display list is generated, it is sent to [WebRender](https://github.com/servo/webrender) for rendering.


### PR DESCRIPTION
Layout 2013 is now [gone](https://servo.org/blog/2025/05/09/this-month-in-servo/).

The wording is just a proof of concept and still up for debate - we can skip this paragraph if it makes the page cleaner to read, since knowing about Layout 2013 doesn't really bring much for a new contributor IMO.