### PR TITLE
Remove duplicate section about updating test expectations

### DIFF
--- a/src/hacking/testing.md
+++ b/src/hacking/testing.md
@@ -38,19 +38,6 @@ To run a test:
 ./mach test-wpt tests/wpt/yourtest
 ```
 
-## Updating a test
-
-In some cases, extensive tests for the feature you're working on already exist under tests/wpt:
-
-- Make a release build
-- run `./mach test-wpt --release --log-raw=/path/to/some/logfile`
-- run [`update-wpt` on it](#updating-web-test-expectations)
-
-This may create a new commit with changes to expectation ini files.
-If there are lots of changes, it's likely that your feature had tests in wpt already.
-
-Include this commit in your pull request.
-
 ## Add a new test
 
 If you need to create a new test file, it should be located in `tests/wpt/mozilla/tests` or in `tests/wpt/tests` if it's something that doesn't depend on servo-only features.


### PR DESCRIPTION
There are currently two sections on how to update web platform test expectations:
* https://book.servo.org/hacking/testing.html#updating-a-test
* https://book.servo.org/hacking/testing.html#updating-web-platform-test-expectations


This change removes the first one, as it is less detailed and even contains incorrect information about commits being created by `./mach update-wpt`.