### PR TITLE
ci: Optimize images on push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,25 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Optimize images
+        run: |
+          export IFS=
+          git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | while read -r file;
+            do
+            if [ "$(xdg-mime query filetype $file)" == "image/png" ]; then
+              which oxipng || cargo install oxipng
+              oxipng -o max -a -s "$file"
+              oxipng -o max --zopfli -a -s "$file"
+            fi
+          done
+      - name: Commit and push optimized images
+        run: |-
+          git config user.name "[bot]"
+          git config user.email "actions@users.noreply.github.com"
+          git add -A
+          git commit -m "Optimize images" || exit 0
+          git pull --rebase
+          git push
       - name: Configure PATH
         run: |
           mkdir -p opt/mdbook


### PR DESCRIPTION
Adds steps to the deploy action that check for any PNG files and compress them with oxipng. Marking as draft, since there's a few details to iron out:

- Currently this makes a new commit with the images to keep the repo up to date. This theoretically makes the repo larger on clones without a shallower depth set. We could avoid this by squashing the commit, but that might remove the running action indicator (minor, actions can be accesed in the Actions tab). The generated page should be unaffected.
- The oxipng flags are currently all set to max, with a non-zopfli and zopfli run, the same way I run them locally. This can cause significant delays when pushing very large (2k or above, bad dithering patterns, etc) images. This might be fine as the average image is pretty small and pushing changes isn't that time sensitive, but we should discuss potentially bumping the flags down if it's an issue.

Once these are discussed and settled, this PR should ideally be applied to the servo.org site as well.