### PR TITLE
ci: Generate a list of links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Generate link list
+        run: |
+          grep -Rin --include="*.md" -E -o "https?://[a-zA-Z0-9./?#=_%:-]*" src >> src/links.txt
       - name: Configure PATH
         run: |
           mkdir -p opt/mdbook


### PR DESCRIPTION
This is the first step towards https://github.com/servo/servo/issues/38952.  This produces a file which will be available at book.servo.org/links.txt. Every line in the file follows this syntax: `file:line_number:link`.