### PR TITLE
ci: Automated book link health check

### DIFF
--- a/.github/workflows/link-health.yml
+++ b/.github/workflows/link-health.yml
@@ -8,59 +8,10 @@ jobs:
   link-health:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
       - name: Fetch link list
         run: |
-          wget https://book.servo.org/links.txt
-      - name: Check availability of links
-        run: |
-          set +e
-          let ok=0
-          let warn=0
-          let error=0
-          let ignored=0
-          ignore=(
-            # Internal GitHub asset link, appears in an example of an error
-            # in hacking/web-compat-bugs.md and not meant to be useable.
-            https://github.githubassets.com
-            # Example of locally hosted WPT tests.
-            http://web-platform.test:8000
-            # Do not play nice with curl (fake 4XX).
-            https://www.researchgate.net
-            https://crates.io
-            https://developer.huawei.com
-            https://gitee.com
-          )
-          while IFS= read -r line; do
-            link=$( echo "$line" | cut -d":" -f3- )
-            for item in "${ignore[@]}"; do
-              if [[ $link == $item* ]]; then
-                echo "Skipping ignored link $link" >> log.txt
-                ((++ignored))
-                continue 2
-              fi
-            done
-            # Avoid accidentally DDOSing repeated usages of the same link.
-            if [[ $lastlink != $link ]]; then
-              status=$( curl -o /dev/null -A "Servo book link health check (https://github.com/servo/book)" -s -w "%{http_code}\n" $link )
-            fi
-            lastlink=$link
-            case ${status:0:1} in
-              3)
-                echo "WARNING: $status at $line" >> log.txt
-                ((++warn))
-                ;;
-              2)
-                echo "OK: $status at $line" >> log.txt
-                ((++ok))
-                ;;
-              *)
-                echo "ERROR: $status at $line" >> log.txt
-                ((++error))
-                ;;
-            esac
-          done < "links.txt"
-          echo "" >> log.txt
-          echo "$ok OK, $warn warnings, $error errors, $ignored ignored" >> log.txt
+          ./link-health.sh
       - uses: actions/upload-artifact@v4
         with:
           name: Link health report

--- a/.github/workflows/link-health.yml
+++ b/.github/workflows/link-health.yml
@@ -1,0 +1,67 @@
+name: Check link health
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  link-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch link list
+        run: |
+          wget https://book.servo.org/links.txt
+      - name: Check availability of links
+        run: |
+          set +e
+          let ok=0
+          let warn=0
+          let error=0
+          let ignored=0
+          ignore=(
+            # Internal GitHub asset link, appears in an example of an error
+            # in hacking/web-compat-bugs.md and not meant to be useable.
+            https://github.githubassets.com
+            # Example of locally hosted WPT tests.
+            http://web-platform.test:8000
+            # Do not play nice with curl (fake 4XX).
+            https://www.researchgate.net
+            https://crates.io
+            https://developer.huawei.com
+            https://gitee.com
+          )
+          while IFS= read -r line; do
+            link=$( echo "$line" | cut -d":" -f3- )
+            for item in "${ignore[@]}"; do
+              if [[ $link == $item* ]]; then
+                echo "Skipping ignored link $link" >> log.txt
+                ((++ignored))
+                continue 2
+              fi
+            done
+            # Avoid accidentally DDOSing repeated usages of the same link.
+            if [[ $lastlink != $link ]]; then
+              status=$( curl -o /dev/null -A "Servo book link health check (https://github.com/servo/book)" -s -w "%{http_code}\n" $link )
+            fi
+            lastlink=$link
+            case ${status:0:1} in
+              3)
+                echo "WARNING: $status at $line" >> log.txt
+                ((++warn))
+                ;;
+              2)
+                echo "OK: $status at $line" >> log.txt
+                ((++ok))
+                ;;
+              *)
+                echo "ERROR: $status at $line" >> log.txt
+                ((++error))
+                ;;
+            esac
+          done < "links.txt"
+          echo "" >> log.txt
+          echo "$ok OK, $warn warnings, $error errors, $ignored ignored" >> log.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Link health report
+          path: log.txt

--- a/link-health.sh
+++ b/link-health.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+wget https://book.servo.org/links.txt
+set +e
+let ok=0
+let warn=0
+let error=0
+ignore=(
+  # Internal GitHub asset link, appears in an example of an error
+  # in hacking/web-compat-bugs.md and not meant to be useable.
+  https://github.githubassets.com
+  # Example of locally hosted WPT tests.
+  http://web-platform.test:8000
+  # Do not play nice with curl (fake 4XX).
+  https://www.researchgate.net
+  https://crates.io
+  https://developer.huawei.com
+  https://gitee.com
+)
+while IFS= read -r line; do
+  link=$( echo "$line" | cut -d":" -f3- )
+  for item in "${ignore[@]}"; do
+    if [[ $link == $item* ]]; then
+      echo "Skipping ignored link $link" >> log.txt
+      continue 2
+    fi
+  done
+  # Avoid accidentally DDOSing repeated usages of the same link.
+  if [[ $lastlink != $link ]]; then
+    status=$( curl -o /dev/null -A "Servo book link health check (https://github.com/servo/book)" -s -w "%{http_code}\n" $link )
+  fi
+  lastlink=$link
+  case ${status:0:1} in
+    3)
+      echo "WARNING: $status at $line" >> log.txt
+      ((++warn))
+      ;;
+    2)
+      echo "OK: $status at $line" >> log.txt
+      ((++ok))
+      ;;
+    *)
+      echo "ERROR: $status at $line" >> log.txt
+      ((++error))
+      ;;
+  esac
+done < "links.txt"
+echo "" >> log.txt
+echo "$ok OK, $warn warnings, $error errors" >> log.txt
+rm links.txt


### PR DESCRIPTION
Adds a GitHub action which runs a daily job and produces a text file artifact. The file contains a list of each link and the status code it returned, as well as a brief summary at the end.

Some links are ignored: check the ignore list near the top of the run script for comments on why.

Question: should we use the GitHub action artifact feature or store the logs elsewhere?