### PR TITLE
Remove C++ MFC requirement from Windows setup instructions

### DIFF
--- a/src/hacking/setting-up-your-environment.md
+++ b/src/hacking/setting-up-your-environment.md
@@ -50,8 +50,6 @@ Note that `curl` will already be installed on Windows 1804 or newer.
     (`Microsoft.VisualStudio.Component.VC.Tools.x86.x64`)
   - **C++ ATL for latest v143 build tools (x86 & x64)**<br>
     (`Microsoft.VisualStudio.Component.VC.ATL`)
-  - **C++ MFC for latest v143 build tools (x86 & x64)**<br>
-    (`Microsoft.VisualStudio.Component.VC.ATLMFC`)
 
 <div class="warning _note">
 


### PR DESCRIPTION
My new laptop was dead.
I resurrected my old laptop and rebuilt everything from scratch. It has limited hardware.
Turns out C++ MFC is simply not needed. This saves about 3GB space.

Windows always build mozjs/mozangle, so we can update them too.