### PR TITLE
Add a Rust style guide

### DIFF
--- a/src/contributing/style-guide.md
+++ b/src/contributing/style-guide.md
@@ -12,7 +12,8 @@ In general, all Rust code in Servo is automatically formatted via `rustfmt` when
 In addition, Rust code should use [Rust API naming conventions](https://rust-lang.github.io/api-guidelines/naming.html).
 There are a few non-obvious points in the naming conventions guide such as:
 
-- With a few exceptions, the `get_` prefix is not used for getters in Rust code.
+- The `get_` prefix is generally not used for getters in Rust code.
+  An exception to this rule is when it is used for a variant of a `get()` method like in `std::cell::Cell::get_mut()`.
 - When camel-casing, acronyms and contractions of compound words count as one word.
   For instance, a struct should be called `HtmlParser` and not `HTMLParser`.
 


### PR DESCRIPTION
This change adds an initial Rust style guide. There is probably a good
deal of refinement and addition that can go here, but this is just the
start.

Fixes #147.
