### PR TITLE
Allow title case

### DIFF
--- a/src/contributing/style-guide.md
+++ b/src/contributing/style-guide.md
@@ -28,7 +28,6 @@ Note that these should be quoted as well.
 
 ## Servo Book
 
-- Use sentence case for chapter and section headings, e.g. “Getting started” rather than “Getting Started”
 - Use permalinks when linking to source code repos — press `Y` in GitHub to get a permanent URL
 
 ### Markdown source


### PR DESCRIPTION
this patch updates the style guide to remove the rule about using sentence case for titles, since we’ve started moving away from that in #167. i don’t feel strongly about that rule since it was mostly aesthetic, unlike our rules about things like permalinks and error messages, and i think we should only have rules that we actually want to follow.