### PR TITLE
Link is wrong (URL opens with `(` but closes with `]`).

### DIFF
--- a/src/trying/running-servoshell.md
+++ b/src/trying/running-servoshell.md
@@ -16,7 +16,7 @@ $ ./servo --help
 
 Servo has in-progress support for many web platform features.
 Some are not complete enough to be enabled by default, but you can try them out using a preference setting.
-For a list of these features and the preference used to enable them, see [Experimental features](../design-documentation/experimental-features.md].
+For a list of these features and the preference used to enable them, see [Experimental features](../design-documentation/experimental-features.md).
 In addition, you can enable a useful subset of these features with the `--enable-experimental-web-platform-features` command-line argument or via the servoshell user interface.
 
 ## Keyboard shortcuts


### PR DESCRIPTION
Link is wrong (URL opens with `(` but closes with `]`).

_Originally posted by @sfiedler0 in https://github.com/servo/book/pull/182#discussion_r2637047819_
            