### PR TITLE
Improve the link check script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,9 @@ jobs:
           fetch-depth: 0
       - name: Generate link list
         run: |
-          grep -Rin --include="*.md" -E -o "https?://[a-zA-Z0-9./?#=_%:-]*" src >> src/links.txt
+          for link in $(grep -Rin --include="*.md" -E -o "https?://[a-zA-Z0-9./?#=_%:-]*[^\.]" src); do
+            echo "$link" | sed 's/\.$//' >> src/links.txt
+          done
       - name: Configure PATH
         run: |
           mkdir -p opt/mdbook

--- a/link-health.sh
+++ b/link-health.sh
@@ -10,7 +10,11 @@ ignore=(
   https://github.githubassets.com
   # Example of locally hosted WPT tests.
   http://web-platform.test:8000
+  # Local URLs.
+  http://127.0.0.1
+  http://localhost
   # Do not play nice with curl (fake 4XX).
+  https://medium.com
   https://www.researchgate.net
   https://crates.io
   https://developer.huawei.com


### PR DESCRIPTION
A bit of routine maintenance on the link checkup script. Adds a few new things to the ignore and fixes a bug where the trailing dot in one file was treated as part of a link.