### PR TITLE
Document Pyrefly usage in Zed

### DIFF
--- a/src/contributing/editor-setup.md
+++ b/src/contributing/editor-setup.md
@@ -99,9 +99,11 @@ In your `./zed/settings.json` file you need something like this:
 
 ### Python
 
-Servo contains Python scripts as part of build tooling and certain types of tests. Zed's default Python configuration might not be able to provide proper static code analysis.
+Servo contains Python scripts as part of build tooling and certain types of tests.
+Zed's default Python configuration might not be able to provide proper static code analysis.
 
-Servo is configured to work with the Pyrefly language server, which you can enable with something resembling the below config. You will also need to install the [Pyrefly](https://zed.dev/extensions/pyrefly) Zed extension.
+Servo is configured to work with the Pyrefly language server, which you can enable with something resembling the below config.
+You will also need to install the [Pyrefly](https://zed.dev/extensions/pyrefly) Zed extension.
 
 ```json
 {

--- a/src/contributing/editor-setup.md
+++ b/src/contributing/editor-setup.md
@@ -97,6 +97,38 @@ In your `./zed/settings.json` file you need something like this:
 }
 ```
 
+### Python
+
+Servo contains Python scripts as part of build tooling and certain types of tests. Zed's default Python configuration might not be able to provide proper static code analysis.
+
+Servo is configured to work with the Pyrefly language server, which you can enable with something resembling the below config. You will also need to install the [Pyrefly](https://zed.dev/extensions/pyrefly) Zed extension.
+
+```json
+{
+  "lsp": {
+    "pyrefly": {
+      "binary": {
+        "path": ".venv/bin/pyrefly",
+        "arguments": ["lsp"],
+      },
+      "settings": {
+        "python": {
+          "pythonPath": ".venv/bin/python",
+        },
+        "pyrefly": {
+          "python_interpreter": ".venv/bin/python",
+        },
+      },
+    },
+  },
+  "languages": {
+    "Python": {
+      "language_servers": ["pyrefly", "!pyright", "!pylsp"],
+    },
+  },
+}
+```
+
 ### NixOS
 
 If you are on NixOS, you might get errors about `pkg-config` or `crown`:


### PR DESCRIPTION
Adds instructions for enabling the Pyrefly LSP in Servo.

The change to yaml formatting is to not highlight the JSON comment as an error