### PR TITLE
Update supported Openharmony SDK Version

### DIFF
--- a/src/building/openharmony.md
+++ b/src/building/openharmony.md
@@ -14,7 +14,7 @@ Building for OpenHarmony requires the following:
 ### Setting up the OpenHarmony SDK
 
 The OpenHarmony SDK is required to compile applications for OpenHarmony.
-The minimum version of SDK that Servo currently supports is v5.0.2 (API-14).
+The minimum version of SDK that Servo currently supports is v6.0.0 (API-20).
 
 #### Downloading via DevEco Studio
 


### PR DESCRIPTION
The required version was bumped in https://github.com/servo/servo/pull/42404. The HarmonyOS version was later also set to API-20 in https://github.com/servo/servo/pull/42595.

Fixes: https://github.com/servo/servo/issues/45016