### PR TITLE
Remove broken link in "Design Documentation" index to "Implementing a DOM API"

### DIFF
--- a/src/design-documentation/script/index.md
+++ b/src/design-documentation/script/index.md
@@ -217,8 +217,6 @@ TODO:
 
 Current state of, and outlook on, Servo's integration of SpiderMonkey: [https://github.com/gterzian/spidermonkey_servo](https://github.com/servo/servo/wiki/Servo-and-SpiderMonkey-Report)
 
-- [How to work on a Web API](../guides/implementing-a-dom-api.md)
-
 ## Script Thread
 
 - [Microtask queuing](microtasks.md)


### PR DESCRIPTION
While browsing the book, I found this broken link.