### PR TITLE
Explain how to run DevTools tests on the CI

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -39,7 +39,7 @@
   - [OpenHarmony](contributing/debugging/openharmony.md)
 - [Profiling](contributing/profiling.md)
 - [Crate Dependencies](contributing/crate-dependencies.md)
-- [Devtools](contributing/devtools.md)
+- [DevTools](contributing/devtools.md)
 - [Guides](contributing/guides/index.md)
   - [Minimal Reproducible Test Cases](contributing/guides/minimal-reproducible-test-cases.md)
   - [Implementing a DOM API](contributing/guides/implementing-a-dom-api.md)

--- a/src/contributing/devtools.md
+++ b/src/contributing/devtools.md
@@ -1,4 +1,4 @@
-# Devtools
+# DevTools
 
 [Firefox DevTools](https://firefox-source-docs.mozilla.org/devtools-user) are a set of web developer tools that can be used to examine, edit, and debug a website's HTML, CSS, and JavaScript.
 Servo has support for a subset of DevTools functionality, allowing for simple debugging.

--- a/src/contributing/making-a-pull-request.md
+++ b/src/contributing/making-a-pull-request.md
@@ -136,3 +136,8 @@ If you do not have permission to add labels to your pull request, add a comment 
 | `T-linux-wpt`      | Linux              | Linux                      |
 | `T-macos`          | macOS              | (none)                     |
 | `T-windows`        | Windows            | (none)                     |
+
+The DevTools tests are experimental and not yet enabled by default.
+It is highly recommended that pull requests that modify DevTools code run them.
+To do so, add the `T-linux-devtools` label.
+As with Web Platform Tests, if you do not have permission to add labels, comment to request that it is added.

--- a/src/contributing/testing.md
+++ b/src/contributing/testing.md
@@ -172,10 +172,10 @@ This is equivalent to running
 
     ./mach test-wpt --manifest-update SKIP_TESTS
 
-## Running Devtools Tests
+## Running DevTools Tests
 
-The simplest way to run the Devtools tests in Servo is `./mach test-devtools` from the root directory.
-This will run all tests defined in `devtools_tests.py`. All Devtools-related test files exist in `python/servo/devtools_tests`.
+The simplest way to run the DevTools tests in Servo is `./mach test-devtools` from the root directory.
+This will run all tests defined in `devtools_tests/test_*.py`. All DevTools-related test files exist in `python/servo/devtools_tests`.
 
 ## Alternatives to running web platform tests
 


### PR DESCRIPTION
Additionally, replace "Devtools" with "DevTools" to use consistent spelling across different files. The test file has also been updated to reflect the new split test structure.

Any suggestions for the text in `src/contributing/making-a-pull-request.md` are greatly appreciated.